### PR TITLE
One to many item keys contains duplicates

### DIFF
--- a/graphene_pynamodb/relationships.py
+++ b/graphene_pynamodb/relationships.py
@@ -51,7 +51,7 @@ class RelationshipResultList(list):
             yield RelationshipResult(self._hash_key_name, key, self._model)
 
     def resolve(self):
-        models = dict((getattr(entity, self._hash_key_name), entity) for entity in self._model.batch_get(self._keys))
+        models = dict((getattr(entity, self._hash_key_name), entity) for entity in self._model.batch_get(list(set(self._keys))))
         return [models[key] for key in self._keys]
 
 

--- a/graphene_pynamodb/tests/test_relationships.py
+++ b/graphene_pynamodb/tests/test_relationships.py
@@ -133,6 +133,28 @@ def test_onetomany_should_serialize_well():
     assert relationship.serialize([fixtures["article1"], fixtures["article2"]]) == [{'N': '1'}, {'N': '2'}]
 
 
+def test_onetomany_should_serialize_well_duplicated_allowed():
+    fixtures = setup_fixtures()
+    relationship = OneToMany(Article)
+    assert relationship.serialize([fixtures["article1"], fixtures["article1"]]) == [{'N': '1'}, {'N': '1'}]
+
+    relationship = OneToMany(Article, uniqueness=False)
+    assert relationship.serialize([fixtures["article1"], fixtures["article1"]]) == [{'N': '1'}, {'N': '1'}]
+
+
+def test_onetomany_should_serialize_well_duplicated_are_cleaned():
+    fixtures = setup_fixtures()
+    relationship = OneToMany(Article, uniqueness='clean')
+    assert relationship.serialize([fixtures["article1"], fixtures["article1"]]) == [{'N': '1'}]
+
+
+def test_onetomany_should_serialize_well_duplicated_throws_error():
+    fixtures = setup_fixtures()
+    relationship = OneToMany(Article, uniqueness='throws')
+    with pytest.raises(Exception):
+        relationship.serialize([fixtures["article1"], fixtures["article1"]])
+
+
 def test_onetomany_should_deserialize_well():
     relationship = OneToMany(Article)
 

--- a/graphene_pynamodb/tests/test_relationships.py
+++ b/graphene_pynamodb/tests/test_relationships.py
@@ -146,6 +146,17 @@ def test_onetomany_should_deserialize_well():
     assert articles[1].headline == "My Article"
 
 
+def test_onetomany_should_resolve_well_duplicated_keys():
+    relationship = OneToMany(Article)
+    article = Article(10, headline="Test", reporter=Reporter(2))
+    article.save()
+
+    articles = relationship.deserialize([10, 10])
+    articles.resolve()
+    assert articles[0].headline == "Test"
+    assert articles[1].headline == "Test"
+
+
 def test_result_should_be_lazy():
     MockArticle = ObjectProxy(Article)
     MockArticle.get = MagicMock(return_value=Article.get(1))

--- a/graphene_pynamodb/utils.py
+++ b/graphene_pynamodb/utils.py
@@ -31,3 +31,8 @@ def connection_for_type(_type):
             return self.total_count if hasattr(self, "total_count") else len(self.edges)
 
     return Connection
+
+
+def unique(sequence):
+    seen = set()
+    return [x for x in sequence if not (x in seen or seen.add(x))]


### PR DESCRIPTION
Hi @yfilali 
I have made some enhancements to OneToMany serialize and deserialize.
1) before this modification save a relationship with the same key duplicated were allowed but at resolve() time boto3 will raise an error with "Provided list of item keys contains duplicates"
see commit #64235f9c5731d5b5a1d836f32d422fb052586cca

2) I've added the uniqueness parameter to OneToMany constructor
if is not set or is set to False if you set a duplicated item in a relation nothing is done
if you set uniqueness='throws' an exception will be raised.
if you set uniqueness='clean' the keys in relation will be deduplicated

Feel free to modify or makes some changes

