### PR TITLE
Adding two CI pipelines to ease release/deploy

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,81 @@
+name: Build & Release
+
+on:
+  push:
+
+jobs:
+  build-n-release:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+
+      - uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6
+        with:
+          python-version: 3.7
+
+      # Did some research and it looks like running the included test suite `python setup.py test`
+      # will need a dynamo-local container hosted as a service in this workflow.
+      - name: Testing Stub
+        run: |
+          echo "Stub for future automated testing"
+
+      - name: Get version
+        id: get-version
+        run: |
+          version=$(grep version setup.py | grep -o "[0-9].[0-9].[0-9]")
+          echo "version: $version"
+          echo "::set-output name=version::$version"
+          #echo "::set-output name=tag_version::v$version"
+
+      - name: Install pypa/build
+        run: python -m pip install build --user
+
+      - name: Build binary wheel and source tarball
+        run: python -m build --sdist --wheel --outdir dist
+
+      - name: "Upload Build Asset: tar"
+        uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
+        with:
+          name: graphene-pynamodb-${{ steps.get-version.outputs.version }}.tar.gz
+          path: ./dist/graphene-pynamodb-${{ steps.get-version.outputs.version }}.tar.gz
+          if-no-files-found: error
+
+      - name: "Upload Build Asset: wheel"
+        uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
+        with:
+          name: graphene_pynamodb-${{ steps.get-version.outputs.version }}-py3-none-any.whl
+          path: ./dist/graphene_pynamodb-${{ steps.get-version.outputs.version }}-py3-none-any.whl
+          if-no-files-found: error
+
+      - name: Check for version bump
+        id: version-bump-check
+        run: |
+          is_bump="false"
+          old_version=$(hub release -L 1)
+
+          if [[ "$VERSION" != "$old_version" ]]; then
+            is_bump="true"
+          fi
+
+          # Testing code
+          echo "old_version: $old_version"
+          echo "version: $VERSION"
+          echo "is_bump: $is_bump"
+
+          echo "::set-output name=is_bump::$is_bump"
+        env:
+          VERSION: ${{ steps.get-version.outputs.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create release
+        if: steps.version-bump-check.outputs.is_bump == 'true' && github.ref == 'refs/heads/master'
+        uses: ncipollo/release-action@95215a3cb6e6a1908b3c44e00b4fdb15548b1e09
+        with:
+          artifacts: |
+            dist/graphene-pynamodb-${{ steps.get-version.outputs.version }}.tar.gz,
+            dist/graphene_pynamodb-${{ steps.get-version.outputs.version }}-py3-none-any.whl
+          commit: ${{ github.sha }}
+          tag: ${{ steps.get-version.outputs.version }}
+          name: "Version ${{ steps.get-version.outputs.version }}"
+          draft: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,44 @@
+name: Publish to PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag_name_input:
+        description: "Release Tag Name <X.X.X>"
+        required: true
+  release:
+    types:
+      - published
+
+
+jobs:
+  build-n-publish:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+
+      - name: get version
+        id: get-version
+        run: |
+          if [[ "${{ github.event_name }}" != "release" ]]; then
+            echo "::set-output name=version::$RELEASE_TAG_NAME_INPUT"
+          else
+            version=$(hub release -L 1)
+            echo "::set-output name=version::$version"
+          fi
+        env:
+          RELEASE_TAG_NAME_INPUT: ${{ github.event.inputs.release_tag_name_input }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: get release assets
+        uses: Xotl/cool-github-releases@16c58a5863d6ba9944f63ca8bb78bb3249ce1d81
+        with:
+          mode: download
+          tag_name: ${{ steps.get-version.outputs.version }}
+          assets: graphene-pynamodb-${{ steps.get-version.outputs.version }}.tar.gz|./dist/graphene-pynamodb-${{ steps.get-version.outputs.version }}.tar.gz;graphene_pynamodb-${{ steps.get-version.outputs.version }}-py3-none-any.whl|./dist/graphene_pynamodb-${{ steps.get-version.outputs.version }}-py3-none-any.whl
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+.venv
 
 # C extensions
 *.so


### PR DESCRIPTION
## Summary
Added two CI pipelines: 1) Build & Release, and 2) Publish to PyPI to ease in releasing this project.

### Build & Release
This pipeline grabs the version from the `setup.py` file, builds the release assets and attaches them to the pipeline. It then checks to see if the version has been bumped and the current branch is `master`. If both of these are true, it creates a draft release and attaches the build assets to it. 

There is a stub in this pipeline to add in the testing suite, but adding the `dynamodb-local` was something that I didn't have time to do.

### Publish to PyPI
Once release notes have been added to the draft release and everything looks good, publishing the release will kick off the Publish pipeline. This grabs the release assets from the most recent release (the one that was just published) and then automatically submits the entire `./dist` directory to PyPI. This will require a PIPY_API_TOKEN to be added to this repo under `Settings => Secrets => Repository Secrets`. Everything has been tested up to this point on my fork.

## Notes
:warning: PIPY_API_TOKEN needs to be added to this repository's settings (see above)